### PR TITLE
Document variable default values in cruise definition files

### DIFF
--- a/_docs/cached_data_server.md
+++ b/_docs/cached_data_server.md
@@ -8,21 +8,49 @@ toc_icon: "list"
 toc_sticky: true  # Makes the TOC stick on scroll
 ---
 
-This document describes configuration, operation and use of the
-[CachedDataServer code](https://github.com/OceanDataTools/openrvdas/blob/master/server/cached_data_server.py) that is used
-to feed display widgets and provide intermediate caching for derived
-data transforms and others.
+The [CachedDataServer](https://github.com/OceanDataTools/openrvdas/blob/master/server/cached_data_server.py) accepts timestamped field:value data, holds it in an in-memory cache, and serves it to clients over WebSockets. It is used to feed display widgets, to provide intermediate caching for derived-data transforms, and as a general-purpose data bus between OpenRVDAS components.
 
-If you are using the default OpenRVDAS installation, you will have a
-CachedDataServer running and servicing websocket connections on port
-8766.
+In the default OpenRVDAS installation a CachedDataServer is already running and listening for WebSocket connections on port **8766**.
 
-If you are manually running a LoggerManager, you may specify that it
-start up its own CachedDataServer by specifying the ``--start_data_server``
-argument on its command line. You may also invoke a standalone
-CachedDataServer directly from the command line (as is done by the script
-in ``scripts/start_openrvdas.sh`` in your local installation). The
-following command line
+---
+
+## Running the Server
+
+### Default installation
+
+The default installation uses `supervisord` to start and maintain the server:
+
+```
+server/cached_data_server.py --port 8766 \
+    --disk_cache /var/tmp/openrvdas/disk_cache \
+    --max_records 86400 -v
+```
+
+This serves WebSocket connections on port 8766, retains at most 86400 records per field (one day at 1 Hz), and maintains a disk cache at `/var/tmp/openrvdas/disk_cache` that is used to warm the in-memory cache on restart. It does **not** listen on a UDP port — all data arrives via WebSocket `publish` messages.
+
+Stdout and stderr are written to `/var/log/openrvdas/cached_data_server.std{out,err}`. The full supervisord spec is in `/etc/supervisor/conf.d/openrvdas.conf` (Ubuntu) or `/etc/supervisord.d/openrvdas.ini` (CentOS/Redhat).
+
+To start, stop, or restart the server, use the supervisord web interface at [http://openrvdas:9001](http://openrvdas:9001) or the command line:
+
+```
+root@openrvdas:~# supervisorctl
+cached_data_server               RUNNING   pid 5641, uptime 1:35:54
+logger_manager                   RUNNING   pid 5646, uptime 1:35:53
+
+supervisor> stop cached_data_server
+cached_data_server: stopped
+
+supervisor> start cached_data_server
+cached_data_server: started
+
+supervisor> exit
+```
+
+### Manual invocation
+
+You can also run the server directly. If you are running a LoggerManager, pass `--start_data_server` to have it start its own CachedDataServer automatically.
+
+For a standalone server that also listens for data on a UDP port:
 
 ```
 server/cached_data_server.py \
@@ -30,301 +58,527 @@ server/cached_data_server.py \
   --port 8766 \
   --disk_cache /var/tmp/openrvdas/disk_cache \
   --back_seconds 3600 \
-  --cleanup 60 \
-  --v
+  --cleanup_interval 60 \
+  -v
 ```
 
-says to
+### Server command-line flags
 
-1. Listen on the UDP port specified by --network for JSON-encoded,
-   timestamped, field:value pairs. See Data Input Formats, below, for
-   the formats it is able to parse.
+| Flag | Default | Description |
+|---|---|---|
+| `--port` | _(required)_ | WebSocket port to serve clients on |
+| `--udp` | _(none)_ | Comma-separated UDP port(s) to listen for incoming data on. Prefix with a multicast group to use multicast, e.g. `239.0.0.1:6225` |
+| `--disk_cache` | _(none)_ | Directory for the disk-backed cache. On restart, data is reloaded from here to warm the in-memory cache |
+| `--back_seconds` | `86400` | Maximum age (seconds) of data to retain |
+| `--max_records` | `2880` | Maximum number of records to retain per field. Set to `0` for unlimited |
+| `--min_back_records` | `64` | Minimum number of records to keep per field even when purging old data |
+| `--cleanup_interval` | `60` | How often (seconds) to purge old data and flush the disk cache |
+| `--interval` | `0.5` | How often (seconds) the server pushes updates to subscribed clients |
 
-2. Store the received data in memory, retaining the most recent 3600
-   seconds for each field (default is 86400 seconds = 24 hours).
+---
 
-   (The total number of values cached per field is also limited by the
-   ``max_records`` parameter and defaults to 2880, equivalent to two
-   records per minute for 24 hours. It may be overridden to "infinite"
-   by setting ``--max_records=0`` on the command line.)
+## The WebSocket Protocol
 
-3. Periodically back up the in-memory cache to a disk-based cache at
-   /var/tmp/openrvdas/disk_cache (By default, back up every 60
-   seconds; this can be overridden with the ``--cleanup_interval``
-   argument).
+All interaction with the CachedDataServer — reading and writing — happens over a single WebSocket connection. Connect to `ws://host:8766` and exchange JSON messages. Every message you send has a `"type"` field; every response from the server has `"type"`, `"status"` (HTTP-style, e.g. `200`), and `"data"` fields.
 
-4. Wait for clients to connect to the websocket at port 8766 (the
-   default port)and serve them the requested data. Web clients may
-   issue JSON-encoded requests of the following formats (note that the
-   invocation in the default OpenRVDAS installation does *not* listen
-   on a UDP port, and relies on websocket connections for its data).
+### `fields` — list available fields
 
-In the default installation, the ``supervisord`` package starts and
-maintains a cached\_data\_server with the following invocation:
-
-```
-    server/cached_data_server.py --port 8766 \
-        --disk_cache /var/tmp/openrvdas/disk_cache \
-        --max_records 86400 -v
+```json
+{"type": "fields"}
 ```
 
-This invocation serves websocket connections on port 8766, but does
-not listen on any UDP port. It maintains at most 86400 records per
-field (equivalent to 24 hours of 1 Hz reporting), and maintains a disk
-cache in /var/tmp/openrvdas/disk\_cache that it can call on to "warm
-up" the in-memory cache if it is terminated and restarted.
+Returns a list of all field names currently held in the cache:
 
-Its stderr and stdout are written to
-``/var/log/openrvdas/cached_data_server.std[err,out]`` respectively.
-
-The full specification can be found in
-``/etc/supervisor/conf.d/openrvdas.conf`` in Ubuntu and
-``/etc/supervisord.d/openrvdas.ini`` in CentOS/Redhat.
-
-To start/stop/restart the supervisor-maintained configuration, either
-via the local webserver at
-[http://openrvdas:9001](http://openrvdas:9001) (assuming your machine
-is named 'openrvdas') or via the command line ``supervisorctl`` tool:
-
-```
-root@openrvdas:~# supervisorctl
-cached_data_server               RUNNING   pid 5641, uptime 1:35:54
-logger_manager                   RUNNING   pid 5646, uptime 1:35:53
-simulate_nbp                     RUNNING   pid 5817, uptime 1:23:46
-
-supervisor> stop cached_data_server
-cached_data_server: stopped
-
-supervisor> status
-cached_data_server               STOPPED   Oct 05 04:58 AM
-logger_manager                   RUNNING   pid 5646, uptime 1:36:02
-simulate_nbp                     RUNNING   pid 5817, uptime 1:23:55
-
-supervisor> start cached_data_server
-cached_data_server: started
-
-supervisor> status
-cached_data_server               RUNNING   pid 15187, uptime 0:00:03
-logger_manager                   RUNNING   pid 5646, uptime 1:36:09
-simulate_nbp                     RUNNING   pid 5817, uptime 1:24:02
-
-supervisor> exit
+```json
+{"type": "data", "status": 200, "data": ["S330CourseTrue", "S330SpeedKt", ...]}
 ```
 
-# Websocket Request Types
+### `describe` — get field metadata
 
-The data server knows how to respond to a set of requests sent to it
-by websocket clients:
+```json
+{"type": "describe", "fields": ["S330CourseTrue", "S330SpeedKt"]}
+```
 
-## {"type":"fields"}
-  ```
-  {"type":"fields"}
-  ```
+Returns a dict of metadata (units, description, device, etc.) for each named field. Omit `"fields"` to get metadata for every field in the cache:
 
-   Return a list of fields for which cache has data.
-
-## {"type":"describe"}
-  ```
-  {'type':'describe',
-    'fields':['field_1', 'field_2', 'field_3']}
-  ```
-
-  Return a dict of metadata descriptions for each specified field. If
-  'fields' is omitted, return a dict of metadata for *all* fields.
-
-## {"type":"subscribe"}
-  ```
-  {"type":"subscribe",
-    "fields":{"field_1":{"seconds":50},
-              "field_2":{"seconds":0},
-              "field_3":{"seconds":-1}}}
-  ```
-
-  Subscribe to updates for field\_1, field\_2 and field\_3. Allowable
-  values for 'seconds':
-
-  - ``0``  - provide only new values that arrive after subscription
-  - ``-1``  - provide the most recent value, and then all future new ones
-  - ``num`` - provide num seconds of back data, then all future new ones
-
-
-  If 'seconds' is missing, use '0' as the default.
-
-  The entire specification may also have a field called 'interval',
-  specifying how often server should provide updates. Will
-  default to what was specified on command line with --interval
-  flag (which itself defaults to 1 second intervals):
-
-  ```
-  {"type":"subscribe",
-    "fields":{"field_1":{"seconds":50},
-              "field_2":{"seconds":0},
-              "field_3":{"seconds":-1}},
-   "interval": 15
+```json
+{
+  "type": "data", "status": 200,
+  "data": {
+    "S330CourseTrue": {"description": "True course", "units": "degrees", ...},
+    "S330SpeedKt":   {"description": "Speed in knots", "units": "kt", ...}
   }
-  ```
+}
+```
 
-  The subscription message may also have an optional 'format' field,
-  which may have the value 'field\_dict' (the default) or
-  'record\_list':
+### `subscribe` — stream field updates
 
-  ```
-  {"type":"subscribe",
-    "fields":{"field_1":{"seconds":50},
-              "field_2":{"seconds":0},
-              "field_3":{"seconds":-1}},
-   "format": "record_list"
+Subscribing is a two-step loop: send a `subscribe` message once to register interest, then send `ready` repeatedly to receive successive batches of updates.
+
+```json
+{
+  "type": "subscribe",
+  "fields": {
+    "S330CourseTrue": {"seconds": 30},
+    "S330SpeedKt":    {"seconds": 0},
+    "S330HeadingTrue":{"seconds": -1}
   }
-  ```
-  
-  Field names can also use * as a wildcard, in which case all fields
-  that match the pattern will be returned:
-  
-  ```
-  {"type":"subscribe",
-    "fields":{"field_*":{"seconds":50},
-              "field_3":{"seconds":-1}},
-   "format": "record_list"
-  }
-  ```
+}
+```
 
-  If 'record\_list' is specified, results will be collated into a list
-  of DASRecord-like dicts:
+The `"seconds"` value controls how much historical data is returned in the first response:
 
-  ```
-  [
-    {
-      'timestamp': timestamp,
-      'fields': {field_name: value, field_name: value, ...}
-    },
-    {
-      'timestamp': timestamp,
-      'fields': {field_name: value, field_name: value, ...}
-    },
-    ...  
-  ]
-  ```
+| `seconds` value | Meaning |
+|---|---|
+| `0` | Only new values that arrive after the subscription |
+| `-1` | The single most recent value, then all future new values |
+| `N` (positive) | Up to N seconds of historical data, then all future new values |
 
-  If 'field\_dict' is specified (or if 'format' is left unspecified),
-  results will be provided as a field dict:
+If `"seconds"` is omitted, `0` is used.
 
-  ```
-  {
-    'fields': {
-      field_name: [(timestamp, value), (timestamp, value),...],
-      field_name: [(timestamp, value), (timestamp, value),...],
-      ...
+**`back_records`** (optional, per-field): guarantee a minimum number of historical records regardless of the `seconds` window. Useful when data arrives irregularly:
+
+```json
+{"S330CourseTrue": {"seconds": 60, "back_records": 10}}
+```
+
+**`interval`** (optional, top-level): override the server's default push interval (seconds). Useful for low-bandwidth clients or slow-changing data:
+
+```json
+{
+  "type": "subscribe",
+  "fields": {"S330CourseTrue": {"seconds": 0}},
+  "interval": 15
+}
+```
+
+**Wildcards**: field names may contain `*` to match multiple fields:
+
+```json
+{"type": "subscribe", "fields": {"S330*": {"seconds": -1}}}
+```
+
+**`format`** (optional, top-level): controls the shape of the `data` payload in each response.
+
+`"field_dict"` (default) — a dict mapping each field name to a list of `[timestamp, value]` pairs:
+
+```json
+{
+  "S330CourseTrue": [[1714000000.0, 219.6], [1714000001.0, 219.7], ...],
+  "S330SpeedKt":   [[1714000000.0, 8.9],   [1714000001.0, 8.9],   ...]
+}
+```
+
+`"record_list"` — collated by timestamp into a list of DASRecord-like dicts. Useful when processing records in time order across multiple fields:
+
+```json
+{
+  "type": "subscribe",
+  "fields": {"S330CourseTrue": {"seconds": 30}, "S330SpeedKt": {"seconds": 30}},
+  "format": "record_list"
+}
+```
+
+Response `data`:
+
+```json
+[
+  {"timestamp": 1714000000.0, "fields": {"S330CourseTrue": 219.6, "S330SpeedKt": 8.9}},
+  {"timestamp": 1714000001.0, "fields": {"S330CourseTrue": 219.7, "S330SpeedKt": 8.9}},
+  ...
+]
+```
+
+### `ready` — acknowledge and receive the next batch
+
+After the initial `subscribe` response, send `ready` each time you are prepared to receive the next update:
+
+```json
+{"type": "ready"}
+```
+
+The server responds with a `data` message containing all field values that have arrived since the previous `ready`. This back-pressure mechanism prevents a slow client from being overwhelmed with buffered data.
+
+### `publish` — write data into the cache
+
+Any WebSocket client can push data into the cache using a `publish` message:
+
+```json
+{
+  "type": "publish",
+  "data": {
+    "timestamp": 1555468528.452,
+    "fields": {
+      "field_1": "value_1",
+      "field_2": "value_2"
     }
   }
-  ```
+}
+```
 
-## {"type":"ready"}
-  ```
-  {"type":"ready"}
-  ```
+This is the mechanism used by the [CachedDataWriter](https://github.com/OceanDataTools/openrvdas/blob/master/logger/writers/cached_data_writer.py) component to feed data into the server.
 
-  Indicate that client is ready to receive the next set of updates
-  for subscribed fields.
+---
 
-## {"type": "publish"}
-  ```
-  {"type":"publish", "data":{"timestamp":1555468528.452,
-                              "fields":{"field_1":"value_1",
-                                        "field_2":"value_2"}}}
-  ```
+## Reading from the Server
 
-  Submit new data to the cache. This is the mechanism that the
-  [CachedDataWriter component](https://github.com/OceanDataTools/openrvdas/blob/master/logger/writers/cached_data_writer.py)
-  component uses to send data to the server.
+### listen.py
 
-# Feeding the CachedDataServer
+[`logger/listener/listen.py`](https://github.com/OceanDataTools/openrvdas/blob/master/logger/listener/listen.py) accepts a `--cached_data` argument that subscribes to one or more fields and prints received records to stdout. Useful for quick inspection and for piping CDS data into other command-line tools.
 
-As indicated above, there are several ways of feeding the server with
-data to cache.
+```
+logger/listener/listen.py --cached_data field_1,field_2,field_3
+```
 
-1. A process that has instantiated a CachedDataServer object can
-   directly call its ``cache_record()`` method. See [the code
-   itself](https://github.com/OceanDataTools/openrvdas/blob/master/server/cached_data_server.py) or [the pdoc-extracted
-   code documentation
-   page](https://htmlpreview.github.io/?https://raw.githubusercontent.com/oceandatatools/openrvdas/master/docs/html/server/cached_data_server.html)
-   for details.
+Connects to `localhost:8766` by default. To target a different host or port, append `@host:port`:
 
-2. By connecting to the server with a websocket and sending it a
-   ``publish`` message, as described in [Websocket Request
-   Types](websocket-request-types), above.
+```
+logger/listener/listen.py --cached_data S330CourseTrue,S330SpeedKt@192.168.1.10:8766
+```
 
-3. By broadcasting a JSON-encoded dict of data (described below) on
-   UDP to a port that the data server is listening on, if the data
-   server has been invoked with a ``--data_server_udp`` argument.
-   The service start script created by the default installation does
-   *not* listen to a UDP port; this can be changed by uncommenting the
-   line in ``scripts/start_openrvdas.sh`` that reads:
+All subscribed fields use `seconds: 0` — only values that arrive after the subscription starts are returned. The `--cached_data` flag can be combined with other `listen.py` transforms and writers in the usual way:
 
-   ```
-   #DATA_SERVER_LISTEN_ON_UDP='--udp $DATA_SERVER_UDP_PORT'
-   ```
+```
+logger/listener/listen.py \
+  --cached_data S330CourseTrue,S330SpeedKt \
+  --transform_prefix vessel \
+  --write_logfile /var/tmp/log/s330
+```
 
-# Input Data Formats
+### Interactive exploration
 
-Whether by UDP or websocket, the CachedDataServer expects to be
-passed records in the format of a dict encoding optionally a
-source data\_id and timestamp and a mandatory 'fields' key of
-field\_name: value pairs. This is the format emitted by default
-by ParseTransform:
+For ad-hoc queries or protocol debugging, any interactive WebSocket client works. Two popular command-line options are [`wscat`](https://github.com/websockets/wscat) (Node.js) and [`websocat`](https://github.com/vi/websocat) (Rust).
 
-   ```
-   {
-     "data_id": ...,    # optional
-     "timestamp": ...,  # optional - use time.time() if missing
-     "fields": {
-       field_name: value,
-       field_name: value,
-       ...
-     }
-   }
-   ```
+List all cached fields:
 
-A twist on this is that the values may either be a singleton
-(int, float, string, etc) or a list. If the value is a singleton,
-it is taken at face value. If it is a list, it is assumed to be a
-list of (value, timestamp) tuples, in which case the top-level
-timestamp, if any, is ignored.
+```
+$ wscat -c ws://localhost:8766
+Connected (press CTRL+C to quit)
+> {"type":"fields"}
+< {"type": "data", "status": 200, "data": ["S330CourseTrue", "S330SpeedKt", ...]}
+```
 
-   ```
-   {
-     "data_id": ...,  # optional
-     "fields": {
-        field_name: [(timestamp, value), (timestamp, value),...],
-        field_name: [(timestamp, value), (timestamp, value),...],
-        ...
-     }
-   }
-   ```
+Get the most recent value of a field and exit:
 
-In addition to a 'fields' field, a record may contain a 'metadata'
-field. If present, the data server will look for a 'fields' dict
-inside the metadata dict and add the key-value pairs there to its
-cache of metadata about the fields:
+```
+$ echo '{"type":"subscribe","fields":{"S330CourseTrue":{"seconds":-1}}}' \
+  | websocat ws://localhost:8766
+```
 
-   ```
-   {'data_id': 's330',
-    'fields': {'S330CourseMag': 244.29,
-               'S330CourseTrue': 219.61,
-               'S330Mode': 'A',
-               'S330SpeedKm': 16.5,
-               'S330SpeedKt': 8.9},
-    'metadata': {'fields': {
-      'S330CourseMag': {'description': 'Magnetic course',
-                        'device': 's330',
-                        'device_type': 'Seapath330',
-                        'device_type_field': 'CourseMag',
-                        'units': 'degrees'},
-      'S330CourseTrue': {'description': 'True course',
-                         ...}
-      }
-   }}
-   ```
+### CachedDataReader in a YAML config file
 
-This metadata field will be generated sent at intervals by a
-RecordParser (and its enclosing ParseTransform) if the parser's
-``metadata_interval`` value is not None.
+[`CachedDataReader`](https://github.com/OceanDataTools/openrvdas/blob/master/logger/readers/cached_data_reader.py) is the standard component for pulling data from the CDS inside a logger configuration.
+
+```yaml
+readers:
+  class: CachedDataReader
+  kwargs:
+    data_server: localhost:8766
+    subscription:
+      fields:
+        S330CourseTrue:
+          seconds: 0
+        S330SpeedKt:
+          seconds: -1
+        S330HeadingTrue:
+          seconds: 60
+```
+
+All subscription options from the [WebSocket protocol](#subscribe--stream-field-updates) — wildcards, `back_records`, `interval`, `format` — are available inside the `subscription` dict.
+
+As a convenience, `fields` may be given as a list instead of a dict; all fields are then subscribed with `seconds: 0`:
+
+```yaml
+readers:
+  class: CachedDataReader
+  kwargs:
+    data_server: localhost:8766
+    subscription:
+      fields:
+        - S330CourseTrue
+        - S330SpeedKt
+        - S330HeadingTrue
+```
+
+**CachedDataReader parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `data_server` | `localhost:8766` | Host and port of the CachedDataServer |
+| `subscription` | _(required)_ | Subscription dict (see above) |
+| `bundle_seconds` | `0` | If > 0, accumulate records for this many seconds and return them as a list |
+| `return_das_record` | `False` | If `True`, wrap results in `DASRecord` objects |
+| `data_id` | `None` | `data_id` to assign to returned `DASRecord` objects (requires `return_das_record=True`) |
+| `use_wss` | `False` | Connect using secure WebSockets (`wss://`) |
+| `check_cert` | `False` | Verify the server's TLS certificate; may be a path to a `.pem` file |
+
+Example — read two fields and write them to a logfile:
+
+```yaml
+readers:
+  class: CachedDataReader
+  kwargs:
+    data_server: localhost:8766
+    subscription:
+      fields:
+        S330CourseTrue:
+          seconds: 0
+        S330SpeedKt:
+          seconds: 0
+writers:
+  class: LogfileWriter
+  kwargs:
+    filebase: /var/tmp/log/s330_derived
+```
+
+### CachedDataReader in Python
+
+```python
+from logger.readers.cached_data_reader import CachedDataReader
+
+subscription = {
+    'fields': {
+        'S330CourseTrue': {'seconds': 30},
+        'S330SpeedKt':    {'seconds': -1},
+    }
+}
+
+reader = CachedDataReader(subscription=subscription, data_server='localhost:8766')
+
+while True:
+    record = reader.read()  # blocks until data arrives
+    print(record)
+    # {'timestamp': ..., 'fields': {'S330CourseTrue': ..., 'S330SpeedKt': ...}}
+```
+
+To return `DASRecord` objects instead of plain dicts:
+
+```python
+reader = CachedDataReader(
+    subscription=subscription,
+    data_server='localhost:8766',
+    return_das_record=True,
+    data_id='s330_consumer',
+)
+record = reader.read()  # returns a DASRecord
+```
+
+To accumulate a time window of records before returning:
+
+```python
+reader = CachedDataReader(
+    subscription=subscription,
+    data_server='localhost:8766',
+    bundle_seconds=5,
+)
+records = reader.read()  # returns a list of dicts
+```
+
+### External Python (asyncio + websockets)
+
+Any Python program can talk to the CachedDataServer directly using the `websockets` library:
+
+```python
+import asyncio
+import json
+import websockets
+
+async def read_fields():
+    async with websockets.connect('ws://localhost:8766') as ws:
+        # Subscribe
+        await ws.send(json.dumps({
+            'type': 'subscribe',
+            'fields': {
+                'S330CourseTrue': {'seconds': 60},
+                'S330SpeedKt':    {'seconds': -1},
+            }
+        }))
+        await ws.recv()  # discard subscribe acknowledgement
+
+        # Poll for updates
+        while True:
+            await ws.send(json.dumps({'type': 'ready'}))
+            response = json.loads(await ws.recv())
+            if response.get('status') == 200:
+                for field, values in response.get('data', {}).items():
+                    for timestamp, value in values:
+                        print(f'{field}: {value} @ {timestamp}')
+            await asyncio.sleep(1)
+
+asyncio.run(read_fields())
+```
+
+One-shot query for the most recent value of all fields matching a pattern:
+
+```python
+async def latest_values(pattern='S330*'):
+    async with websockets.connect('ws://localhost:8766') as ws:
+        await ws.send(json.dumps({
+            'type': 'subscribe',
+            'fields': {pattern: {'seconds': -1}},
+        }))
+        await ws.recv()  # discard subscribe acknowledgement
+        await ws.send(json.dumps({'type': 'ready'}))
+        response = json.loads(await ws.recv())
+        return response.get('data', {})
+
+data = asyncio.run(latest_values())
+```
+
+### JavaScript (browser)
+
+The OpenRVDAS `WidgetServer` class in [`display/js/widgets/widget_server.js`](https://github.com/OceanDataTools/openrvdas/blob/master/display/js/widgets/widget_server.js) handles the subscribe/ready loop automatically and dispatches incoming data to a list of display widgets:
+
+```javascript
+var widgets = [
+  new TextWidget('course_div', {'S330CourseTrue': {'seconds': 0}}, 'Degrees'),
+  new TextWidget('speed_div',  {'S330SpeedKt':    {'seconds': 0}}, 'kt'),
+];
+
+var server = new WidgetServer(widgets, 'ws://localhost:8766');
+server.serve();
+```
+
+For custom pages that don't use the widget framework, the raw browser WebSocket API works the same way:
+
+```javascript
+const ws = new WebSocket('ws://localhost:8766');
+
+ws.onopen = () => {
+  ws.send(JSON.stringify({
+    type: 'subscribe',
+    fields: {
+      S330CourseTrue: {seconds: 60},
+      S330SpeedKt:    {seconds: -1},
+    },
+    format: 'record_list',
+  }));
+};
+
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.type === 'data' && msg.status === 200) {
+    // msg.data is an array of {timestamp, fields} objects
+    console.log(msg.data);
+  }
+  ws.send(JSON.stringify({type: 'ready'}));
+};
+```
+
+---
+
+## Writing to the Server
+
+### CachedDataWriter in a YAML config file
+
+[`CachedDataWriter`](https://github.com/OceanDataTools/openrvdas/blob/master/logger/writers/cached_data_writer.py) is the standard component for pushing data into the CDS from a logger pipeline:
+
+```yaml
+writers:
+  class: CachedDataWriter
+  kwargs:
+    data_server: localhost:8766
+```
+
+It accepts `DASRecord` or dict-format records and forwards them to the server via WebSocket `publish` messages. If the connection is lost, it buffers up to `max_backup` records (default: 86400) locally until it can reconnect.
+
+### UDP input
+
+If the server is started with one or more `--udp` ports, it will also accept JSON-encoded records broadcast on those ports:
+
+```
+server/cached_data_server.py --port 8766 --udp 6225
+```
+
+The default supervisord installation does **not** enable UDP input. To enable it, uncomment the relevant line in `scripts/start_openrvdas.sh`:
+
+```bash
+#DATA_SERVER_LISTEN_ON_UDP='--udp $DATA_SERVER_UDP_PORT'
+```
+
+### Direct Python API
+
+Code that instantiates a `CachedDataServer` object directly (rather than connecting to a running server) can call `cache_record()` directly:
+
+```python
+from server.cached_data_server import CachedDataServer
+
+server = CachedDataServer(port=8766)
+server.cache_record({
+    'timestamp': time.time(),
+    'fields': {'field_1': 'value_1', 'field_2': 'value_2'}
+})
+```
+
+---
+
+## Input Data Formats
+
+Whether data arrives via UDP, WebSocket `publish`, or direct `cache_record()` call, the server expects records in one of the following formats.
+
+**Standard format** — a dict with an optional `data_id` and `timestamp`, and a mandatory `fields` key:
+
+```json
+{
+  "data_id": "s330",
+  "timestamp": 1555468528.452,
+  "fields": {
+    "S330CourseMag":  244.29,
+    "S330CourseTrue": 219.61,
+    "S330SpeedKt":    8.9
+  }
+}
+```
+
+`data_id` is optional. `timestamp` is optional — `time.time()` is used if absent.
+
+**Pre-timestamped format** — field values may themselves be lists of `(timestamp, value)` pairs, in which case the top-level `timestamp` is ignored:
+
+```json
+{
+  "fields": {
+    "S330CourseMag":  [[1555468527.1, 244.1], [1555468528.4, 244.29]],
+    "S330CourseTrue": [[1555468527.1, 219.5], [1555468528.4, 219.61]]
+  }
+}
+```
+
+**With metadata** — a record may include a `metadata` key. The server extracts the `fields` dict inside it and caches it as per-field metadata, which is then returned by `describe` requests. This metadata is emitted at intervals by `RecordParser`/`ParseTransform` when `metadata_interval` is set:
+
+```json
+{
+  "data_id": "s330",
+  "fields": {"S330CourseMag": 244.29, "S330CourseTrue": 219.61},
+  "metadata": {
+    "fields": {
+      "S330CourseMag":  {"description": "Magnetic course", "units": "degrees", ...},
+      "S330CourseTrue": {"description": "True course",     "units": "degrees", ...}
+    }
+  }
+}
+```
+
+---
+
+## Quick Reference
+
+**Reading:**
+
+| Method | When to use |
+|---|---|
+| `listen.py --cached_data` | Command-line inspection; piping into other tools |
+| `wscat` / `websocat` | Interactive protocol debugging |
+| `CachedDataReader` in YAML | Reading CDS data inside a logger or derived-data pipeline |
+| `CachedDataReader` in Python | Scripted consumers within the OpenRVDAS codebase |
+| `asyncio` + `websockets` | External Python programs or services |
+| JavaScript `WidgetServer` | Browser display pages using the built-in widget framework |
+| Raw `WebSocket` (JS/other) | Custom browser pages or other language bindings |
+
+**Writing:**
+
+| Method | When to use |
+|---|---|
+| `CachedDataWriter` in YAML | Feeding the CDS from a logger pipeline |
+| WebSocket `publish` message | Any WebSocket client pushing data directly |
+| `--udp` port | Legacy UDP broadcast from instruments or other processes |
+| `cache_record()` in Python | In-process use when directly instantiating a `CachedDataServer` |

--- a/_docs/cruise_definition_files.md
+++ b/_docs/cruise_definition_files.md
@@ -212,8 +212,8 @@ This form of logger definition can be mixed and matched with the traditional for
 
 ### Variables
 
-OpenRVDAS now supports a simple use of variables in a cruise definition file. If defined as a dict under a top-level `variables` key, the loading script will look for instances of the variables enclosed in `<<double_angle_brackets>>` and perform text substitutions.
-```
+OpenRVDAS supports variables in a cruise definition file. If defined as a dict under a top-level `variables` key, the loading script will look for instances of the variables enclosed in `<<double_angle_brackets>>` and perform text substitutions.
+```yaml
 ###########################################################
 # Global variables - can be overridden by individual loggers
 variables:
@@ -221,7 +221,7 @@ variables:
   raw_udp_port: 6224
   file_root: /var/tmp/log
   parse_definition_path: test/NBP1406/devices/nbp_devices.yaml
- 
+
 ###########################################################
 # Optional cruise metadata
 cruise:
@@ -229,6 +229,40 @@ cruise:
   start: "2014-06-01"  # Quoted so YAML doesn't auto-convert to a datetime
   end: "2014-07-01"
 ```
+
+#### Variable Default Values
+
+Variable placeholders may include a default value using a `|` separator. If the named variable is not defined, the default is used instead:
+
+```
+<<var_name|default_value>>
+```
+
+For example, a template that falls back to a standard baud rate when none is provided by the logger:
+
+```yaml
+baudrate: <<baud_rate|9600>>
+```
+
+Default values may themselves be variable references, enabling chains of fallbacks:
+
+```yaml
+# Use baud_rate if defined, otherwise fall back to default_baud, otherwise use 9600
+baudrate: <<baud_rate|<<default_baud|9600>>>>
+```
+
+The full set of supported substitution forms is:
+
+| Syntax | Behavior |
+|---|---|
+| `<<var>>` | Replace with the value of `var` |
+| `<<var\|default>>` | Replace with `var` if defined; otherwise use the literal string `default` |
+| `<<var\|<<fallback>>>>` | Replace with `var` if defined; otherwise use the value of `fallback` |
+| `<<var\|<<fallback\|default>>>>` | Replace with `var`, then `fallback`, then the literal `default` |
+
+**Type conversion**: literal default values are automatically converted to the appropriate Python type. For example, `<<timeout|10>>` produces the integer `10` (not the string `"10"`) when `timeout` is undefined. The values `true`/`false` become Python booleans, `null` becomes `None`, and numeric strings become `int` or `float` as appropriate.
+
+**Pass-through**: if a variable is undefined and has no default, the placeholder is passed through unchanged (e.g. `<<unknown_var>>` remains `<<unknown_var>>` in the output). This is useful for multi-level templates where outer templates leave some variables to be resolved by an inner context.
 
 ### Logger Templates
 


### PR DESCRIPTION
Add a new subsection describing the <<var|default>> substitution syntax introduced in OceanDataTools/openrvdas#475, including nested defaults, type conversion, and pass-through behaviour for unresolved placeholders.